### PR TITLE
perf: return early in get() if path does not exists

### DIFF
--- a/packages/content/src/raw/index.ts
+++ b/packages/content/src/raw/index.ts
@@ -101,7 +101,7 @@ export class API {
    *  - Validates schema + transforms representation -> typed before read
    */
   async get(root: CID, path: string, opts: SchemaOptions): Promise<any> {
-    let value: any = {};
+    let value: any;
     let cid: CID;
     let timerId: ReturnType<typeof setTimeout>;
 

--- a/packages/content/test/raw.test.ts
+++ b/packages/content/test/raw.test.ts
@@ -153,7 +153,9 @@ describe("resolveRoot", () => {
     const ownerDID = session.did.parent;
 
     const gwContent = new GeoWebContent({ ceramic, ipfs });
-    const emptyRoot = await ipfs.dag.put({}, { storeCodec: "dag-cbor" });
+    const emptyRoot = CID.parse(
+      "bafyreigbtj4x7ip5legnfznufuopl4sg4knzc2cof6duas4b3q2fy6swua"
+    );
 
     const result = await gwContent.raw.resolveRoot({ ownerDID, parcelId });
     expect(result).toEqual(emptyRoot);

--- a/packages/content/test/raw.test.ts
+++ b/packages/content/test/raw.test.ts
@@ -153,9 +153,7 @@ describe("resolveRoot", () => {
     const ownerDID = session.did.parent;
 
     const gwContent = new GeoWebContent({ ceramic, ipfs });
-    const emptyRoot = CID.parse(
-      "bafyreigbtj4x7ip5legnfznufuopl4sg4knzc2cof6duas4b3q2fy6swua"
-    );
+    const emptyRoot = await ipfs.dag.put({}, { storeCodec: "dag-cbor" });
 
     const result = await gwContent.raw.resolveRoot({ ownerDID, parcelId });
     expect(result).toEqual(emptyRoot);


### PR DESCRIPTION
If a path doesn't exists `get` returns early, so that we can avoid waiting for network requests that we know would fails to complete.

closes #13 