### PR TITLE
fix: Add short timeout on ipfs resolve

### DIFF
--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geo-web/content",
-  "version": "0.5.3-rc2",
+  "version": "0.5.3-rc3",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geo-web/content",
-  "version": "0.5.3-rc3",
+  "version": "0.5.3-rc4",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geo-web/content",
-  "version": "0.5.2",
+  "version": "0.5.3-rc2",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geo-web/content",
-  "version": "0.5.3-rc5",
+  "version": "0.5.3",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geo-web/content",
-  "version": "0.5.3-rc4",
+  "version": "0.5.3-rc5",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/content/src/raw/index.ts
+++ b/packages/content/src/raw/index.ts
@@ -113,6 +113,7 @@ export class API {
             clearTimeout(timerId);
           }
 
+          console.log(`Found ${root.toString()}/${path} from IPFS get`);
           resolve(result.value);
         })
         .catch((err) => {
@@ -127,6 +128,7 @@ export class API {
           try {
             cid = (await this.#ipfs.dag.resolve(root, { path, timeout: 500 }))
               .cid;
+            console.log(`Found ${root.toString()}/${path} from IPFS resolve`);
           } catch (err) {
             console.warn(err);
             return value;

--- a/packages/content/src/raw/index.ts
+++ b/packages/content/src/raw/index.ts
@@ -124,25 +124,28 @@ export class API {
     const gatewayRequest = new Promise((resolve, reject) => {
       timerId = setTimeout(async () => {
         if (this.#ipfsGatewayHost) {
-          let cid: CID;
+          let cid: CID | null = null;
           try {
             cid = (await this.#ipfs.dag.resolve(root, { path, timeout: 500 }))
               .cid;
             console.log(`Found ${root.toString()}/${path} from IPFS resolve`);
           } catch (err) {
             console.warn(err);
-            return value;
+            if ((err as Error).message.includes("no link named")) {
+              return value;
+            }
           }
 
           try {
+            const cidStr = cid ? cid.toString() : `${root.toString}/${path}`;
             // Download raw block
             console.debug(
               `Retrieving raw block from: ${
                 this.#ipfsGatewayHost
-              }/ipfs/${cid.toString()}`
+              }/ipfs/${cidStr}`
             );
             const rawBlock = await axios.get(
-              `${this.#ipfsGatewayHost}/ipfs/${cid.toString()}`,
+              `${this.#ipfsGatewayHost}/ipfs/${cidStr}`,
               {
                 responseType: "arraybuffer",
                 headers: { Accept: "application/vnd.ipld.raw" },

--- a/packages/content/src/raw/index.ts
+++ b/packages/content/src/raw/index.ts
@@ -103,33 +103,35 @@ export class API {
    */
   async get(root: CID, path: string, opts: SchemaOptions): Promise<any> {
     let value: any;
-    let cid: CID;
     let timerId: ReturnType<typeof setTimeout>;
 
-    try {
-      cid = (await this.#ipfs.dag.resolve(root, { path })).cid;
-    } catch (err) {
-      console.warn(err);
-      return value;
-    }
+    const jsIpfsRequest = new Promise((resolve, reject) => {
+      this.#ipfs.dag
+        .get(root, { path })
+        .then((result) => {
+          if (timerId) {
+            clearTimeout(timerId);
+          }
 
-    const jsIpfsRequest = new Promise(async (resolve, reject) => {
-      try {
-        const result = await this.#ipfs.dag.get(cid);
-
-        if (timerId) {
-          clearTimeout(timerId);
-        }
-
-        resolve(result.value);
-      } catch (err) {
-        console.warn(err);
-        reject();
-      }
+          resolve(result.value);
+        })
+        .catch((err) => {
+          console.warn(err);
+          reject(err);
+        });
     });
     const gatewayRequest = new Promise((resolve, reject) => {
       timerId = setTimeout(async () => {
         if (this.#ipfsGatewayHost) {
+          let cid: CID;
+          try {
+            cid = (await this.#ipfs.dag.resolve(root, { path, timeout: 500 }))
+              .cid;
+          } catch (err) {
+            console.warn(err);
+            return value;
+          }
+
           try {
             // Download raw block
             console.debug(

--- a/packages/content/src/raw/index.ts
+++ b/packages/content/src/raw/index.ts
@@ -113,7 +113,7 @@ export class API {
             clearTimeout(timerId);
           }
 
-          console.log(`Found ${root.toString()}/${path} from IPFS get`);
+          console.debug(`Found ${root.toString()}/${path} from IPFS get`);
           resolve(result.value);
         })
         .catch((err) => {
@@ -128,7 +128,7 @@ export class API {
           try {
             cid = (await this.#ipfs.dag.resolve(root, { path, timeout: 500 }))
               .cid;
-            console.log(`Found ${root.toString()}/${path} from IPFS resolve`);
+            console.debug(`Found ${root.toString()}/${path} from IPFS resolve`);
           } catch (err) {
             console.warn(err);
             if ((err as Error).message.includes("no link named")) {
@@ -137,7 +137,7 @@ export class API {
           }
 
           try {
-            const cidStr = cid ? cid.toString() : `${root.toString}/${path}`;
+            const cidStr = cid ? cid.toString() : `${root.toString()}/${path}`;
             // Download raw block
             console.debug(
               `Retrieving raw block from: ${

--- a/packages/content/src/raw/index.ts
+++ b/packages/content/src/raw/index.ts
@@ -117,8 +117,12 @@ export class API {
           resolve(result.value);
         })
         .catch((err) => {
-          console.warn(err);
-          reject(err);
+          console.warn(`IPFS get Error: `, err);
+          if ((err as Error).message.includes("no link named")) {
+            resolve(value);
+          } else {
+            reject(err);
+          }
         });
     });
     const gatewayRequest = new Promise((resolve, reject) => {
@@ -130,7 +134,7 @@ export class API {
               .cid;
             console.debug(`Found ${root.toString()}/${path} from IPFS resolve`);
           } catch (err) {
-            console.warn(err);
+            console.warn(`IPFS resolve Error: `, err);
             if ((err as Error).message.includes("no link named")) {
               return value;
             }


### PR DESCRIPTION
Adds a short timeout on `resolve` to make sure gateway call is still performed.