### PR TITLE
fix - MediaObject and MediaGallery type changes

### DIFF
--- a/packages/types/src/MediaGallery.ts
+++ b/packages/types/src/MediaGallery.ts
@@ -1,10 +1,8 @@
-import { CID } from "multiformats/cid";
-
-export type MediaGallery = CID[];
+export type MediaGallery = string[];
 
 export interface MediaObject {
   name?: string;
-  content: CID;
+  content: string;
   contentSize?: number;
   encodingFormat: Encoding;
 }


### PR DESCRIPTION
* MediaObject content field type changed from CID to string to account for storage providers other than ipfs
* MediaGallery changed from CID array to string array to account for the above